### PR TITLE
Updating link_rel logic 

### DIFF
--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -453,12 +453,16 @@ class LV_Shortcode {
 				$description = ' (' . $link->link_description . ')';
 			}
 			// Check rel attribute.
-			$rel = '';
-			if ( ! empty( $this->atts->link_rel->value ) ) {
+			$rel          = '';
+			$combined_rel = $this->atts->link_rel->value . ' ' . $link->link_rel;
+			if ( ! empty( $combined_rel ) ) {
 				// Check value according to allowed values for HTML5 (see https://www.w3schools.com/tags/att_a_rel.asp).
-				if ( ! empty( $this->atts->link_rel->value ) ) {
-					$rel = ' rel="' . $this->atts->link_rel->value . '"';
-				}
+				$rels = array_intersect(
+					array_unique( explode( ' ', $combined_rel ) ),
+					$this->atts->link_rel->value_options
+				);
+
+				$rel = ' rel="' . implode( ' ', $rels ) . '"';
 			}
 			$out .= '<a class="lv-anchor' . $this->atts->class_suffix->value . '" href="' . $link->link_url . '" target="' . $target . '" title="' . $link->link_name . $description . '"' . $rel . '>';
 		}


### PR DESCRIPTION
Updating rel logic to include value from `$link->link_rel` and check against value_options.

I noticed that you were not including the values from `$link->link_rel` as well as not checking against `$this->atts->link_rel->value_options` like you were previously (as `$this->atts['link_rel']['val']`).

You might not have thought to include the link_rel because you were filtering out XFN values (although it seems like you'd like to add them back in #33) however, other plugins like [Nofollow Links](https://wordpress.org/plugins/nofollow-links/) can add values to link_rel.